### PR TITLE
bugfix for subsetting rows of a data.table

### DIFF
--- a/R/DataFrame.R
+++ b/R/DataFrame.R
@@ -102,7 +102,7 @@ handleRows(x ~ data.frame, i ~ numeric | integer) %m% {
 handleRows(x ~ data.frame, i ~ OneSidedFormula) %m% {
   envir <- environment(i)
   expr <- parse(text = sub("~", "", deparse(i)))
-  handleRows(x, do.call(with, list(x, expr), envir = envir))
+  handleRows(x, eval(expr, envir = x, enclos = envir))
 }
 
 handleRows(x ~ data.frame, i ~ TwoSidedFormula) %m% x


### PR DESCRIPTION
error is hard to reproduce. test only on local data.